### PR TITLE
modify log output format

### DIFF
--- a/include/darknet.h
+++ b/include/darknet.h
@@ -997,6 +997,7 @@ typedef struct darknet_list {
 // } list;
 // -----------------------------------------------------
 
+static char* UUID;
 
 // parser.c
 LIB_API network *load_network(char *cfg, char *weights, int clear);

--- a/src/darknet.c
+++ b/src/darknet.c
@@ -2,6 +2,7 @@
 #include <time.h>
 #include <stdlib.h>
 #include <stdio.h>
+
 #if defined(_MSC_VER) && defined(_DEBUG)
 #include <crtdbg.h>
 #endif

--- a/src/detector.c
+++ b/src/detector.c
@@ -360,7 +360,7 @@ void train_detector(char *datacfg, char *cfgfile, char *weightfile, int *gpus, i
                 best_map = mean_average_precision;
                 printf("mAP more than 80.0 %!\n");
                 char buff[256];
-                sprintf(buff, "%s/%s_mark.weights", backup_directory, base);
+                sprintf(buff, "%s/%s_%d_mark.weights", backup_directory, base, iteration);
                 save_weights(net, buff);
             }
 

--- a/src/detector.c
+++ b/src/detector.c
@@ -312,7 +312,9 @@ void train_detector(char *datacfg, char *cfgfile, char *weightfile, int *gpus, i
             else fprintf(stderr, "\n Tensor Cores are used.\n");
             fflush(stderr);
         }
-        printf("\n %d: %f, %f avg loss, %f rate, %lf seconds, %d images, %f hours left\n", iteration, loss, avg_loss, get_current_rate(net), (what_time_is_it_now() - time), iteration*imgs, avg_time);
+        fprintf(stdout, "\n{ uuid: '%s', training: { iteration: %d, loss: %f, avg_loss: %f, rate: %f, seconds: %lf, eta: %f } }\n", 
+            UUID, iteration, loss, avg_loss, get_current_rate(net), (what_time_is_it_now() - time), avg_time);
+
         fflush(stdout);
 
         int draw_precision = 0;
@@ -354,11 +356,11 @@ void train_detector(char *datacfg, char *cfgfile, char *weightfile, int *gpus, i
             iter_map = iteration;
             mean_average_precision = validate_detector_map(datacfg, cfgfile, weightfile, 0.25, 0.5, 0, net.letter_box, &net_map);// &net_combined);
             printf("\n mean_average_precision (mAP@0.5) = %f \n", mean_average_precision);
-            if (mean_average_precision > best_map) {
+            if (mean_average_precision > 80.0) {
                 best_map = mean_average_precision;
-                printf("New best mAP!\n");
+                printf("mAP more than 80.0 %!\n");
                 char buff[256];
-                sprintf(buff, "%s/%s_best.weights", backup_directory, base);
+                sprintf(buff, "%s/%s_mark.weights", backup_directory, base);
                 save_weights(net, buff);
             }
 
@@ -1931,6 +1933,7 @@ void draw_object(char *datacfg, char *cfgfile, char *weightfile, char *filename,
 
 void run_detector(int argc, char **argv)
 {
+    UUID = find_char_arg(argc, argv, "-uuid", "not defined");   // set as a global variable to use from the log
     int dont_show = find_arg(argc, argv, "-dont_show");
     int benchmark = find_arg(argc, argv, "-benchmark");
     int benchmark_layers = find_arg(argc, argv, "-benchmark_layers");

--- a/src/network_kernels.cu
+++ b/src/network_kernels.cu
@@ -348,8 +348,8 @@ void forward_backward_network_gpu(network net, float *x, float *y)
         cuda_free(state.delta);
         cuda_pull_array(*net.input_gpu, x, x_size);
     }
-    if(*(state.net.total_bbox) > 0)
-        fprintf(stderr, " total_bbox = %d, rewritten_bbox = %f %% \n", *(state.net.total_bbox), 100 * (float)*(state.net.rewritten_bbox) / *(state.net.total_bbox));
+    // if(*(state.net.total_bbox) > 0)
+    //     fprintf(stderr, " total_bbox = %d, rewritten_bbox = %f %% \n", *(state.net.total_bbox), 100 * (float)*(state.net.rewritten_bbox) / *(state.net.total_bbox));
 }
 
 float train_network_datum_gpu(network net, float *x, float *y)

--- a/src/parser.c
+++ b/src/parser.c
@@ -331,7 +331,7 @@ layer parse_conv_lstm(darknet_list *options, size_params params)
     return l;
 }
 
-layer parse_history(list *options, size_params params)
+layer parse_history(darknet_list *options, size_params params)
 {
     int history_size = option_find_int(options, "history_size", 4);
     layer l = make_history_layer(params.batch, params.h, params.w, params.c, history_size, params.time_steps, params.train);

--- a/src/yolo_layer.c
+++ b/src/yolo_layer.c
@@ -662,9 +662,10 @@ void forward_yolo_layer(const layer l, network_state state)
     classification_loss /= l.batch;
     iou_loss /= l.batch;
 
-    fprintf(stderr, "v3 (%s loss, Normalizer: (iou: %.2f, cls: %.2f) Region %d Avg (IOU: %f, GIOU: %f), Class: %f, Obj: %f, No Obj: %f, .5R: %f, .75R: %f, count: %d, class_loss = %f, iou_loss = %f, total_loss = %f \n",
-        (l.iou_loss == MSE ? "mse" : (l.iou_loss == GIOU ? "giou" : "iou")), l.iou_normalizer, l.cls_normalizer, state.index, tot_iou / count, tot_giou / count, avg_cat / class_count, avg_obj / count, avg_anyobj / (l.w*l.h*l.n*l.batch), recall / count, recall75 / count, count,
-        classification_loss, iou_loss, loss);
+    // fprintf(stderr, "v3 (%s loss, Normalizer: (iou: %.2f, cls: %.2f) Region %d Avg (IOU: %f, GIOU: %f), Class: %f, Obj: %f, No Obj: %f, .5R: %f, .75R: %f, count: %d, class_loss = %f, iou_loss = %f, total_loss = %f \n",
+    //     (l.iou_loss == MSE ? "mse" : (l.iou_loss == GIOU ? "giou" : "iou")), l.iou_normalizer, l.cls_normalizer, state.index, tot_iou / count, tot_giou / count, avg_cat / class_count, avg_obj / count, avg_anyobj / (l.w*l.h*l.n*l.batch), recall / count, recall75 / count, count,
+    //     classification_loss, iou_loss, loss);
+    // fprintf(stdout, "class_loss = %-30f iou_loss = %-30f total_loss = %-30f \n", classification_loss, iou_loss, loss);
 }
 
 void backward_yolo_layer(const layer l, network_state state)


### PR DESCRIPTION
- important logs are changed to JSON format with `uuid` property
- this will send to ELK stack to visualize the training transitions to the field engineers
- write weight files have more than 80% of mAP accuracy for each mAP measurement epoch